### PR TITLE
Add target directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 
 # Data directory
 .data/
+
+# Cargo builds and excecutables
+target/*


### PR DESCRIPTION
This helps our linting actions, since the `target/` folders will also contains build JS and CSS files (which should not be linted) 