### PR TITLE
Fix the way we specify the java library path

### DIFF
--- a/main/src/reader/command.rs
+++ b/main/src/reader/command.rs
@@ -89,7 +89,7 @@ fn linux_command(resource_path: PathBuf) -> Command {
     )]);
 
     Command::new("java").envs(envs).args([
-        &format!("-Djava.library.path='{}'", library_path.to_string_lossy()),
+        &format!("-Djava.library.path={}", library_path.to_string_lossy()),
         "-cp",
         &format!(
             "{}:{}",


### PR DESCRIPTION
Noticed a small bug while testing #126 . We shouldn't use quotes around this path, otherwise java can't find this library.