### PR TITLE
Create error component

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -3,6 +3,9 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { listen } from "@tauri-apps/api/event";
 import { InteractionScreen } from "./components/interaction-screen";
 import { SelectProject } from "./components/select_project";
+import ErrorScreen from "./components/error-screen";
+
+var errorLog = [];
 
 export default function App() {
   const [project, setProject] = useState(null);
@@ -17,7 +20,8 @@ export default function App() {
 
 function Session({ project, resetProject, language }) {
   const [, setTagsMap] = useState({});
-  const [, setReaderError] = useState(null);
+  const [readerError, setReaderError] = useState(null);
+  const [errorList, setErrorList] = useState([]);
   const [error, setError] = useState(null);
   const [sessionID, setSessionID] = useState(null);
 
@@ -47,15 +51,18 @@ function Session({ project, resetProject, language }) {
   }, []);
 
   useEffect(() => {
-    const unlisten = listen("reader-error", ({ payload }) =>
-      setReaderError(payload),
-    );
+    const unlisten = listen("reader-error", ({ payload }) => {
+      setReaderError(payload);
+      errorLog.push(payload);
+      setErrorList(errorLog);
+    });
 
     return () => unlisten.then((fn) => fn());
   }, []);
 
   return (
     <div>
+      {readerError && <ErrorScreen errorList={errorList} />}
       {project.name[language]}
       <form action="" onSubmit={startNewSession}>
         <input type="text" name="themeKey" id="themeKey" required />

--- a/frontend/src/assets/styles/components/error-screen.css
+++ b/frontend/src/assets/styles/components/error-screen.css
@@ -1,0 +1,27 @@
+.error-screen {
+  position: fixed;
+  top: 5vh;
+  left: 5vw;
+  z-index: 2;
+  display: flex;
+  gap: 5rem;
+  justify-content: center;
+  align-items: center;
+  width: 90vw;
+  height: 90vh;
+  padding: 2.5rem;
+  border-radius: var(--rounded-base);
+  background-color: red;
+}
+
+.error-screen__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.error-screen__list {
+  overflow: auto;
+}

--- a/frontend/src/assets/styles/components/index.css
+++ b/frontend/src/assets/styles/components/index.css
@@ -1,6 +1,7 @@
 @import url("./option.css");
 @import url("./interaction-screen.css");
 @import url("./options-view.css");
+@import url("./error-screen.css");
 
 .page {
   width: 100%;

--- a/frontend/src/components/error-screen.jsx
+++ b/frontend/src/components/error-screen.jsx
@@ -1,0 +1,32 @@
+export default function ErrorScreen({ errorList }) {
+  return (
+    <div className="error-screen">
+      <svg
+        width="163"
+        height="162"
+        viewBox="0 0 163 162"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle cx="81.8408" cy="81" r="80.9366" fill="currentColor" />
+        <path
+          d="M54.011 115.785L47.0536 108.828L74.8833 80.9981L47.0536 53.1684L54.011 46.2109L81.8408 74.0407L109.671 46.2109L116.628 53.1684L88.7982 80.9981L116.628 108.828L109.671 115.785L81.8408 87.9556L54.011 115.785Z"
+          fill="#CE2626"
+        />
+      </svg>
+      <div className="error-screen__content">
+        <h1>ERROR</h1>
+        <h2>The following errors occured:</h2>
+        <ol className="error-screen__list">
+          {errorList.map((error) => (
+            <li key={error.message}>
+              Kind: {error.kind} <br /> Message: {error.message}
+            </li>
+          ))}
+        </ol>
+        <button type="button" onClick={() => window.location.reload()}>
+          Reload
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR creates an error component to display errors from the back-end. When it's merged this closes #84.

I added a global `errorLog` to:

- keep errors in a log, even when Session component isn't mounted anymore
- because pushing multiple objects to an array through a `useState` set didn't get consistent results.

Right now there is no way to get rid of the errors, so I've added a reload button which refreshes the page/front-end.

To-do:

- [ ] Rebase this or start over
- [ ] Adapt it to new logic with 'errorKind'