### PR TITLE
Add a mock reader for testing/development purposes

### DIFF
--- a/main/src/reader/llrp_reader.rs
+++ b/main/src/reader/llrp_reader.rs
@@ -14,7 +14,7 @@ use super::{
     handle_reader_input,
     messages::{parse_message_and, write_message},
     rospec::construct_default_rospec,
-    ReaderError, ReaderErrorKind, DEFAULT_ROSPEC_ID, REFRESH_INTERVAL,
+    ReaderError, ReaderErrorKind, ReaderProtocol, DEFAULT_ROSPEC_ID, REFRESH_INTERVAL,
 };
 
 const DEFAULT_PORT: u16 = 5084;
@@ -32,8 +32,8 @@ pub struct LLRPReader {
     handle: Option<JoinHandle<()>>,
 }
 
-impl LLRPReader {
-    pub fn new(hostname: String) -> Result<Self, ReaderError> {
+impl ReaderProtocol for LLRPReader {
+    fn new(hostname: String) -> Result<Self, ReaderError> {
         if hostname.len() != 12 {
             return Err(ReaderError {
                 kind: ReaderErrorKind::IncorrectHostname(hostname.clone()),
@@ -54,7 +54,7 @@ impl LLRPReader {
         Ok(reader)
     }
 
-    pub fn start_reading<R: tauri::Runtime>(
+    fn start_reading<R: tauri::Runtime>(
         &mut self,
         app_handle: AppHandle<R>,
     ) -> Result<(), ReaderError> {
@@ -72,7 +72,7 @@ impl LLRPReader {
         Ok(())
     }
 
-    pub fn stop_reading(&mut self, await_confirmation: bool) -> Result<(), ReaderError> {
+    fn stop_reading(&mut self, await_confirmation: bool) -> Result<(), ReaderError> {
         if let Some(handle) = self.handle.take() {
             handle.abort();
         };

--- a/main/src/reader/mock_reader.rs
+++ b/main/src/reader/mock_reader.rs
@@ -1,0 +1,62 @@
+use std::{thread::sleep, time::Duration};
+
+use tauri::{
+    async_runtime::{spawn, JoinHandle},
+    AppHandle, Manager,
+};
+
+use crate::tags::{Tag, TagsMap};
+
+use super::{ReaderProtocol, REFRESH_INTERVAL};
+
+/// Create a MockReader
+///
+/// This reader will sent a set of random tags
+#[derive(Debug)]
+pub struct MockReader {
+    handle: Option<JoinHandle<()>>,
+}
+
+impl ReaderProtocol for MockReader {
+    fn new(_hostname: String) -> Result<Self, super::ReaderError>
+    where
+        Self: Sized,
+    {
+        Ok(MockReader { handle: None })
+    }
+
+    fn start_reading<R: tauri::Runtime>(
+        &mut self,
+        app_handle: AppHandle<R>,
+    ) -> Result<(), super::ReaderError> {
+        let handle = spawn(async move {
+            let sleep_duration = Duration::from_millis(REFRESH_INTERVAL.into());
+            loop {
+                let mut tags = vec![
+                    Tag::random(),
+                    Tag::random(),
+                    Tag::random(),
+                    Tag::random(),
+                    Tag::random(),
+                    Tag::random(),
+                    Tag::random(),
+                    Tag::random(),
+                    Tag::random(),
+                    Tag::random(),
+                ];
+                let new_map = TagsMap::from(tags.drain(..));
+                app_handle.emit_all("updated-tags", new_map).unwrap();
+                sleep(sleep_duration)
+            }
+        });
+        self.handle = Some(handle);
+        Ok(())
+    }
+
+    fn stop_reading(&mut self, _await_confirmation: bool) -> Result<(), super::ReaderError> {
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        };
+        Ok(())
+    }
+}

--- a/main/src/tags.rs
+++ b/main/src/tags.rs
@@ -1,3 +1,4 @@
+use rand::{seq::SliceRandom, thread_rng, Rng};
 use serde;
 use std::{
     collections::HashMap,
@@ -5,15 +6,11 @@ use std::{
     vec::Drain,
 };
 
-#[cfg(test)]
-use rand::{seq::SliceRandom, thread_rng, Rng};
-
 const MAX_STRENGTH: i8 = 0;
 const MIN_STRENGTH: i8 = -80;
 const MAX_ANTENNA: u16 = 8;
 const MIN_ANTENNA: u16 = 1;
 
-#[cfg(test)]
 const MOCK_RFID_TAGS: [&str; 9] = [
     "abc123", "abc456", "abc789", "def123", "def456", "def789", "ghi123", "ghi456", "ghi789",
 ];
@@ -71,7 +68,6 @@ impl Tag {
         })
     }
 
-    #[cfg(test)]
     pub fn random() -> Tag {
         let mut rng = thread_rng();
         let id = MOCK_RFID_TAGS.choose(&mut rng).unwrap().to_string();


### PR DESCRIPTION
As a follow up on #132 , this PR adds a `MockReader` that emulates the `LLRPReader`. This `MockReader` just sents a set of random tags every 500ms.

Just like before adding `MOCK_RFID_READER` to your ENV will switch to the mocked reader.