### PR TITLE
Show readable and actionable errors to the user

### DIFF
--- a/frontend/src/assets/styles/components/start-screen.css
+++ b/frontend/src/assets/styles/components/start-screen.css
@@ -103,6 +103,7 @@
 
 .start-screen__message {
   color: var(--color-purple);
+  white-space: preserve;
 }
 
 .start-screen__message--success {

--- a/frontend/src/components/start_screen.jsx
+++ b/frontend/src/components/start_screen.jsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { invoke } from "@tauri-apps/api/tauri";
 import { save } from "@tauri-apps/api/dialog";
 import projects from "../../../projects";
-import translate from "../locales";
+import translate, { translateError } from "../locales";
 
 const previousHostname = localStorage.getItem("circles.last_hostname");
 
@@ -29,6 +29,7 @@ function StartProject({ setProject, setDarkMode }) {
   async function handleSubmit(e) {
     e.preventDefault();
     setState(STATES.working);
+    setError(null);
 
     const data = new FormData(e.target);
     const projectKey = data.get("projectKey");
@@ -39,9 +40,12 @@ function StartProject({ setProject, setDarkMode }) {
       localStorage.setItem("circles.last_hostname", hostname);
       setDarkMode(darkMode);
       setProject(projects[projectKey]);
-    } catch (e) {
+    } catch (error) {
       setState(STATES.error);
-      setError(e);
+      setError(error);
+      // If an unknown error occurs, we want to log the details so we can see what went wrong
+      // eslint-disable-next-line no-console
+      if (error.kind === "Unknown") console.error(error);
     }
   }
 
@@ -111,7 +115,7 @@ function StartProject({ setProject, setDarkMode }) {
       )}
       {state === STATES.error && (
         <span className="start-screen__message start-screen__message--error">
-          {error}
+          {translateError(error)}
         </span>
       )}
     </form>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -19,5 +19,11 @@
   "start_export_button": "Export",
   "start_export_no_filepath_error": "Please select a location to store the export!",
   "start_export_working": "Exporting data. Please wait...",
-  "start_export_done": "The export is done and saved to your device."
+  "start_export_done": "The export is done and saved to your device.",
+  "error_GeneralError_IncorrectProject": "The project key you entered is not correct.\n Please double check and try again",
+  "error_GeneralError_Unknown": "An unknown error occurred in the application\nPlease restart the application and try again",
+  "error_ReaderError_IncorrectHostname": "The hostname you entered is not correct.\n Please double check the hostname and try again",
+  "error_ReaderError_CouldNotConnect": "Could not connect to the reader.\nPlease check the reader is powered up and connected to the computer",
+  "error_ReaderError_LostConnection": "The connection to the reader was lost.\nPlease check all connections and restart the application",
+  "error_ReaderError_Unknown": "An unknown error occurred in the application\nPlease check all connections and restart the reader and the application"
 }

--- a/frontend/src/locales/index.js
+++ b/frontend/src/locales/index.js
@@ -22,3 +22,13 @@ export default function translate(key, language = "EN") {
   }
   return translation;
 }
+
+/**
+ * Resolve an error from our backend to a translations
+ *
+ * @param {CirclesError} error
+ * @returns string
+ */
+export function translateError(error, language) {
+  return translate(`error_${error.error_type}_${error.kind}`, language);
+}

--- a/main/src/error.rs
+++ b/main/src/error.rs
@@ -1,0 +1,72 @@
+use std::fmt::{Display, Formatter};
+
+use crate::{reader::ReaderError, tags::TagError};
+
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+pub enum GeneralErrorKind {
+    IncorrectProject(String),
+    Unknown,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GeneralError {
+    pub kind: GeneralErrorKind,
+    pub message: String,
+}
+
+impl Display for GeneralError {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match &self.kind {
+            GeneralErrorKind::IncorrectProject(project) => {
+                write!(f, "Could not find project {}", project)
+            }
+            GeneralErrorKind::Unknown => write!(
+                f,
+                "Encountered an unexpected error. Message: {}",
+                self.message
+            ),
+        }
+    }
+}
+
+impl ToString for GeneralErrorKind {
+    fn to_string(&self) -> String {
+        match self {
+            GeneralErrorKind::IncorrectProject(_) => String::from("IncorrectProject"),
+            GeneralErrorKind::Unknown => String::from("Unknown"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub enum CirclesErrorType {
+    GeneralError,
+    ReaderError,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CirclesError {
+    pub error_type: CirclesErrorType,
+    pub kind: String,
+    pub message: String,
+}
+
+impl From<ReaderError> for CirclesError {
+    fn from(error: ReaderError) -> Self {
+        CirclesError {
+            error_type: CirclesErrorType::ReaderError,
+            kind: error.kind.to_string(),
+            message: error.message,
+        }
+    }
+}
+
+impl From<GeneralError> for CirclesError {
+    fn from(error: GeneralError) -> Self {
+        CirclesError {
+            error_type: CirclesErrorType::GeneralError,
+            kind: error.kind.to_string(),
+            message: error.message,
+        }
+    }
+}

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -1,7 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use circles::{export::export_all_data, tags::TagsMap, GlobalState};
+use circles::{error::CirclesError, export::export_all_data, tags::TagsMap, GlobalState};
 use std::fs;
 use tauri::Manager;
 
@@ -11,13 +11,10 @@ async fn select_project(
     app_handle: tauri::AppHandle,
     project_key: String,
     hostname: String,
-) -> Result<(), String> {
+) -> Result<(), CirclesError> {
     state.select_project(project_key)?;
-    if let Err(err) = state.start_reading(hostname, app_handle) {
-        Err(err.to_string())
-    } else {
-        Ok(())
-    }
+    state.start_reading(hostname, app_handle)?;
+    Ok(())
 }
 
 #[tauri::command]

--- a/main/src/reader/error.rs
+++ b/main/src/reader/error.rs
@@ -36,3 +36,14 @@ impl Display for ReaderError {
         }
     }
 }
+
+impl ToString for ReaderErrorKind {
+    fn to_string(&self) -> String {
+        match self {
+            ReaderErrorKind::IncorrectHostname(_) => String::from("IncorrectHostname"),
+            ReaderErrorKind::CouldNotConnect(_) => String::from("CouldNotConnect"),
+            ReaderErrorKind::LostConnection => String::from("LostConnection"),
+            ReaderErrorKind::Unknown => String::from("Unknown"),
+        }
+    }
+}

--- a/main/src/tags.rs
+++ b/main/src/tags.rs
@@ -22,13 +22,13 @@ pub struct Tag {
     pub antenna: u16,
 }
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub struct TagError {
     pub kind: TagErrorKind,
     value: String,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, serde::Serialize)]
 pub enum TagErrorKind {
     Incomplete,
     IncorrectAntenna,


### PR DESCRIPTION
This PR improves our error handling throughout the application, so we can show readable/understandable/actionable errors  to the user:
* All error that are sent to the frontend are resolved to a string, that hides the technical details
* In case an unknown error occurs, we log this in the console so a technical person can improve this