### PR TITLE
Make sure figures don't overflow `Option`

### DIFF
--- a/frontend/src/assets/styles/components/option.css
+++ b/frontend/src/assets/styles/components/option.css
@@ -57,6 +57,15 @@
   max-height: 50%;
 }
 
+.option__figure-container:has(> :nth-child(11)) {
+  gap: 4px;
+  height: 60px;
+}
+
+.option__figure-container:has(> :nth-child(16)) {
+  height: 100px;
+}
+
 .option__amount {
   position: absolute;
   left: 50%;


### PR DESCRIPTION
This PR adds breakpoints in the `Option` component for 11 and 16 participants. The values I took are guesses, based on tests I did with options with 1, 2 and 3 lines of text.