### PR TITLE
Add fade-in animation to figure icon

### DIFF
--- a/frontend/src/assets/styles/components/option.css
+++ b/frontend/src/assets/styles/components/option.css
@@ -37,6 +37,7 @@
   flex-flow: wrap;
   gap: 15px;
   justify-content: center;
+  align-items: center;
   height: 66px;
   max-width: 75%;
   max-height: 50%;
@@ -49,6 +50,20 @@
 
 .option__figure-container:has(> :nth-child(16)) {
   height: 100px;
+}
+
+.option__figure-icon {
+  animation: fade-in 0.25s;
+}
+
+@keyframes fade-in {
+  0% {
+    height: 1%;
+  }
+
+  100% {
+    height: 100%;
+  }
 }
 
 .option__amount {

--- a/frontend/src/components/option.jsx
+++ b/frontend/src/components/option.jsx
@@ -16,6 +16,7 @@ export default function Option({
             {[...Array(amount)].map((value, index) => (
               <svg
                 key={index}
+                className="option__figure-icon"
                 width="15"
                 height="66"
                 viewBox="0 0 15 66"


### PR DESCRIPTION
Fix #93

This PR adds a simple animation to new figure icons when they appear.