### PR TITLE
Fixed issue where big option wouldn't display text in center

### DIFF
--- a/frontend/src/assets/styles/components/option.css
+++ b/frontend/src/assets/styles/components/option.css
@@ -80,8 +80,10 @@
 
 .option--big {
   .option__content {
+    justify-content: center;
     width: 80vh;
     margin: auto;
+    padding-top: 0;
     border-width: 15px;
   }
 


### PR DESCRIPTION
Fixes a bug from #287 where the big option wouldn't display text in the center of the option.