### PR TITLE
Update shuffle condition to account for projects with 1 theme

### DIFF
--- a/frontend/src/components/session.jsx
+++ b/frontend/src/components/session.jsx
@@ -185,13 +185,15 @@ export default function Session({ project, resetProject, language, darkMode }) {
   }, [step, phase, tagsMap, tagCount, registeredAnswersInBackend]);
 
   useEffect(() => {
-    if (phase === 0) {
+    if (phase === 0 && project.themes.length > 1) {
       setThemes(
         shuffle(project.themes)
           .filter((t) => chosenTheme?.key !== t.key)
           .slice(0, 3),
       );
       setChosenTheme(null);
+    } else if (project.themes.length === 1) {
+      setChosenTheme(themes[0]);
     }
   }, [phase]);
 


### PR DESCRIPTION
This PR fixes an issue where projects with only 1 theme (and thus a linear flow) would encounter an error and/or not be able to repeat the flow without refreshing.