### PR TITLE
Disable shuffle on small projects

### DIFF
--- a/frontend/src/components/session.jsx
+++ b/frontend/src/components/session.jsx
@@ -105,7 +105,7 @@ export default function Session({ project, resetProject, language, darkMode }) {
             value: chosenTheme.name[language],
             color:
               COLORS[
-              themes.findIndex((theme) => theme.key === chosenTheme.key)
+                themes.findIndex((theme) => theme.key === chosenTheme.key)
               ],
           },
         ];


### PR DESCRIPTION
For projects with less than 3 themes, the shuffle function is disabled to enhance the circular use of the application.