### PR TITLE
Change max-height/width and % values to height/width and px

### DIFF
--- a/frontend/src/assets/styles/components/option.css
+++ b/frontend/src/assets/styles/components/option.css
@@ -48,17 +48,19 @@
 }
 
 .option__figure-icon {
-  height: 80px;
+  --icon-height: 80px;
+
+  height: var(--icon-height);
   animation: fade-in 0.25s;
 }
 
 @keyframes fade-in {
   0% {
-    height: 1%;
+    height: 1px;
   }
 
   100% {
-    height: 100%;
+    height: var(--icon-height);
   }
 }
 


### PR DESCRIPTION
This PR aims to fix a bug in `WebKit` views (Linux, Mac) to properly display single tokens the first time they are scanned. Currently the icons only show up when a second token is registered on the same answer.

I noticed on Linux (which relies on `webkit2gtk` to display the Tauri app) that if there's only one token registered, the token icon isn't showing. This behaviour was also replicated when we tested the installation with colleagues in January 2025 on a Mac device. Changing how we set the `width` and `height` of some components aims to fix this behaviour. Since I can not test this properly on my Windows device which uses Chromium based `WebView2`, I hope @robbevp you can replicate this behaviour and the proposed fix fixes the issue.

# To replicate/check without a physical reader
- it's advised to put the reader refresh interval in `reader.rs` on a higher value like `2000`
- input one string in `MOCK_RFID_TAGS` from `tags.rs` that resemble a value that we have in our tag database (as PR #336 does)
- start the application, open a project and navigate to the main interaction screen
- if after the set interval one `token` icon is displayed the proposed fix works