### PR TITLE
Filter chosen options if there is no theme available

### DIFF
--- a/frontend/src/components/session.jsx
+++ b/frontend/src/components/session.jsx
@@ -206,9 +206,15 @@ export default function Session({ project, resetProject, language, darkMode }) {
   }
 
   function chooseTheme() {
-    const highestAmount = Math.max(...Object.values(tagCount));
-    const popularAnswers = Object.keys(tagCount).filter(
-      (key) => tagCount[key] === highestAmount,
+    const optionFilter = Object.keys(tagCount)
+      .slice(0, themes.length)
+      .reduce((result, key) => {
+        result[key] = tagCount[key];
+        return result;
+      }, {});
+    const highestAmount = Math.max(...Object.values(optionFilter));
+    const popularAnswers = Object.keys(optionFilter).filter(
+      (key) => optionFilter[key] === highestAmount,
     );
     const chooseRandomKey = Math.floor(Math.random() * popularAnswers.length);
     setChosenTheme(themes[popularAnswers[chooseRandomKey] - 1]);


### PR DESCRIPTION
In the case of there being `n` theme options, but the most popular answer being `n+1`, the application crashes.

This PR adds a function to filter out the answers that are invalid because there being no such theme.