### PR TITLE
Update export function to export data per project

### DIFF
--- a/frontend/src/components/start_screen.jsx
+++ b/frontend/src/components/start_screen.jsx
@@ -162,7 +162,11 @@ function ExportCard() {
   }
 
   return (
-    <form className="start-screen__card" onSubmit={handleSubmit} disabled={[STATES.working, STATES.done].includes(state)}>
+    <form
+      className="start-screen__card"
+      onSubmit={handleSubmit}
+      disabled={[STATES.working, STATES.done].includes(state)}
+    >
       <h2 className="start-screen__title">{translate("start_export_title")}</h2>
       <div className="start-screen__input">
         <label className="start-screen__label" htmlFor="projectKey">
@@ -177,10 +181,7 @@ function ExportCard() {
           required
         />
       </div>
-      <button
-        className="start-screen__button"
-        type="submit"
-      >
+      <button className="start-screen__button" type="submit">
         {translate("start_export_button")}
       </button>
       {state === STATES.working && (

--- a/main/src/export.rs
+++ b/main/src/export.rs
@@ -31,7 +31,7 @@ pub fn export_project_data(
     let mut page = 0;
 
     while page * BATCH_SIZE < count {
-        match fetch_batch_and_write(connection, worksheet, &project_key,page * BATCH_SIZE) {
+        match fetch_batch_and_write(connection, worksheet, &project_key, page * BATCH_SIZE) {
             Ok(()) => page += 1,
             Err(err) => return Err(err.to_string()),
         }

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -41,7 +41,11 @@ fn close_connection(state: tauri::State<GlobalState>) -> () {
 }
 
 #[tauri::command]
-async fn save_export(state: tauri::State<'_, GlobalState>, filepath: String, project_key: String) -> Result<(), String> {
+async fn save_export(
+    state: tauri::State<'_, GlobalState>,
+    filepath: String,
+    project_key: String,
+) -> Result<(), String> {
     // NOTE: This allows any arbitrary project_key, but will simply not find results if the project key does not exists
     // Once we move projects to the database, we'll solve this in a more fundamental way
     let mut connection = state.database_connection.lock().unwrap();


### PR DESCRIPTION
Fixes #355 

This updates our export function to export data per project.
I changed the start screen so that it includes a form to enter the project key, once we rework this screen this can be a button per project that passes the correct value