### PR TITLE
Enable devtools in production builds

### DIFF
--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.8.2", features = [ "window-set-fullscreen", "dialog-save", "updater", "shell-open", "process-command-api", "test" ] }
+tauri = { version = "1.8.2", features = [ "window-set-fullscreen", "dialog-save", "updater", "shell-open", "process-command-api", "test", "devtools" ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 diesel = { version = "2.2.9", features = ["sqlite", "time", "returning_clauses_for_sqlite_3_35"] }


### PR DESCRIPTION
This change will allow production builds to also open the devtools. This should make it easier for us to understand what goes wrong in case of issues.

Since we are only using this application on hardware we own and trust, I don't consider it a risk to allow devtools (which would be the case if end-users would install the app on their devices)