### PR TITLE
Make sure we fetch projects when app renders

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -32,7 +32,7 @@ export default function App() {
     });
   }
 
-  useEffect(() => fetchProjects, []);
+  useEffect(() => fetchProjects(), []);
 
   useEffect(() => {
     document.addEventListener("keydown", handleKeydown);


### PR DESCRIPTION
We previously passed the function to the `useEffect`, so `fetchProjects` was only executed when the component was re-rendered or removed. 

This re-rendering happens more/consistently in development, but doesn't happen in production. That why we didn't catch this when working locally, but why the production app couldn't find a project after the reader was connected and `setProjectKey` was executed.