### PR TITLE
Remove title screen step when going back

### DIFF
--- a/frontend/src/components/session.jsx
+++ b/frontend/src/components/session.jsx
@@ -272,14 +272,11 @@ export default function Session({ project, resetProject, language, darkMode }) {
 
   function goToPreviousStep() {
     switch (step) {
-      case STEPS.showBigTitle:
+      case STEPS.showBigQuestion:
         if (phase > 0) {
           setPhase((currentPhase) => currentPhase - 1);
           setStep(STEPS.showMainInteractionScreen);
         }
-        break;
-      case STEPS.showBigQuestion:
-        setStep(STEPS.showBigTitle);
         break;
       case STEPS.showMainInteractionScreen:
         if (phase === 0) {


### PR DESCRIPTION
This PR fixes #364.

We could improve the `goToPreviousStep()` function by creating an undo stack (if that's the correct title). This would make the going to the previous step more realistic. But I don't think that's into scope now.