### PR TITLE
Fix crash when going back to previous step on text screens

### DIFF
--- a/frontend/src/components/session.jsx
+++ b/frontend/src/components/session.jsx
@@ -35,6 +35,8 @@ export default function Session({ project, resetProject, language, darkMode }) {
 
   const currentQuestion =
     chosenTheme !== null && chosenTheme.questions[phase - 1];
+  const previousQuestion =
+    chosenTheme !== null && chosenTheme.questions[phase - 2];
   const description =
     step === STEPS.showMainInteractionScreen
       ? translate("answer_instruction", language)
@@ -275,7 +277,11 @@ export default function Session({ project, resetProject, language, darkMode }) {
       case STEPS.showBigQuestion:
         if (phase > 0) {
           setPhase((currentPhase) => currentPhase - 1);
-          setStep(STEPS.showMainInteractionScreen);
+          if (previousQuestion.type === "text") {
+            setStep(STEPS.showBigQuestion);
+          } else {
+            setStep(STEPS.showMainInteractionScreen);
+          }
         }
         break;
       case STEPS.showMainInteractionScreen:
@@ -289,7 +295,11 @@ export default function Session({ project, resetProject, language, darkMode }) {
         setStep(STEPS.showMainInteractionScreen);
         break;
       case STEPS.showFact:
-        setStep(STEPS.showBigOption);
+        if (currentQuestion.type === "quiz") {
+          setStep(STEPS.showBigOption);
+        } else if (currentQuestion.type === "opinion") {
+          setStep(STEPS.showMainInteractionScreen);
+        }
         break;
     }
   }


### PR DESCRIPTION
There was an issue where the app crashed sometimes when going back to a previous screen. This was due to a wrong definition when going back to a previous step when `STEPS.showFact` and `STEPS.showBigQuestion` were active. This PR fixes the issue.