### PR TITLE
Add setState to idle when close button is clicked on export dialog

### DIFF
--- a/frontend/src/components/popups/delete_project_data.jsx
+++ b/frontend/src/components/popups/delete_project_data.jsx
@@ -25,7 +25,11 @@ export default function DeleteData({ deleteDialog, selectedProjectKey }) {
   }
 
   return (
-    <dialog className="dialog" ref={deleteDialog}>
+    <dialog
+      className="dialog"
+      ref={deleteDialog}
+      onClose={() => setState(STATES.idle)}
+    >
       <div className="start-screen__popup">
         <h2 className="dialog__title--red">
           {translate("start_delete_title")}

--- a/frontend/src/components/popups/export_project_data.jsx
+++ b/frontend/src/components/popups/export_project_data.jsx
@@ -42,7 +42,11 @@ export default function ExportCard({ exportDialog, selectedProjectKey }) {
   }
 
   return (
-    <dialog className="dialog" ref={exportDialog}>
+    <dialog
+      className="dialog"
+      ref={exportDialog}
+      onClose={() => setState(STATES.idle)}
+    >
       <div className="start-screen__popup">
         <h2 className="dialog__title">{translate("start_export_title")}</h2>
         <span className="dialog__label">
@@ -74,10 +78,7 @@ export default function ExportCard({ exportDialog, selectedProjectKey }) {
           <button
             type="button"
             className="start-screen__button start-screen__button--outline"
-            onClick={() => {
-              exportDialog.current?.close();
-              setState(STATES.idle);
-            }}
+            onClick={() => exportDialog.current?.close()}
           >
             {translate("close_button")}
           </button>

--- a/frontend/src/components/popups/import_project.jsx
+++ b/frontend/src/components/popups/import_project.jsx
@@ -32,7 +32,11 @@ export default function ImportCard({ importDialog }) {
   }
 
   return (
-    <dialog className="dialog" ref={importDialog}>
+    <dialog
+      className="dialog"
+      ref={importDialog}
+      onClose={() => setState(STATES.idle)}
+    >
       <div className="start-screen__popup">
         <h2 className="dialog__title">{translate("import_project")}</h2>
         <span className="dialog__label">

--- a/frontend/src/components/popups/start_project.jsx
+++ b/frontend/src/components/popups/start_project.jsx
@@ -55,7 +55,11 @@ export default function StartProject({
   }
 
   return (
-    <dialog className="dialog" ref={startDialog}>
+    <dialog
+      className="dialog"
+      ref={startDialog}
+      onClose={() => setState(STATES.idle)}
+    >
       <form
         action=""
         onSubmit={handleSubmit}


### PR DESCRIPTION
This PR fixes a bug where the state would remain on success, even when the dialog was closed and before a new export was initiated.

This PR doesn't add an event listener for when the modal is closed through the `ESC` key.
@robbevp I couldn't think of an efficient way to do this, so I left this open for now. If you have a proposition to add this functionality I'm open to hear your feedback.