### PR TITLE
Remove double colon

### DIFF
--- a/main/src/export.rs
+++ b/main/src/export.rs
@@ -90,7 +90,7 @@ fn fetch_batch_and_write(
         .load::<(Answer, Step, Session)>(connection)
         .unwrap();
 
-    let format = Format::new().set_num_format("yyyy-mm-dd hh::mm:ss");
+    let format = Format::new().set_num_format("yyyy-mm-dd hh:mm:ss");
     let language = project.available_languages.first().unwrap();
 
     for (row, (answer, step, session)) in results.iter().enumerate() {


### PR DESCRIPTION


This PR removes a typo where the timestamp format would have a double colon instead of a single one.
